### PR TITLE
Fix broken require of .remarkrc.js

### DIFF
--- a/lib/rules/remark.js
+++ b/lib/rules/remark.js
@@ -5,6 +5,7 @@
 const _ = require('lodash')
 const remark = require('remark')
 const fs = require('fs')
+const path = require('path')
 // const { showInvisibles, generateDifferences } = require('prettier-linter-helpers')
 
 // const { INSERT, DELETE, REPLACE } = generateDifferences
@@ -87,7 +88,7 @@ module.exports = {
           if (fs.existsSync('./.remarkrc')) {
             remarkOptionsFromFile = JSON.parse(fs.readFileSync('./.remarkrc', 'utf8'))
           } else if (fs.existsSync('./.remarkrc.js')) {
-            remarkOptionsFromFile = require('./.remarkrc.js')
+            remarkOptionsFromFile = require(path.join(process.cwd(), './.remarkrc.js'))
           }
         }
         const remarkOptions = _.merge({ plugins: [] }, remarkOptionsFromFile, context.options[0])


### PR DESCRIPTION
Currently the plugin errors if you create a '.remarkrc.js' file: `Cannot find module './.remarkrc.js'`
The issue is that `require` resolves relative to the current file, while `fs.exists` resolves relative to cwd. The `require` wasn't reading the same path as the `fs.exists`, instead it was trying to read the file relative to this file i.e. `./node_modules/eslint-plugin-md/lib/rules/.remarkrc.js`.